### PR TITLE
Added the base-components repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,6 @@ add_subdirectory(base-imagemath)
 add_subdirectory(base-askapparallel)
 add_subdirectory(base-scimath)
 add_subdirectory(base-accessors)
+add_subdirectory(base-components)
 add_subdirectory(yandasoft)
+

--- a/repos.txt
+++ b/repos.txt
@@ -7,4 +7,5 @@ base-imagemath
 base-askapparallel
 base-scimath
 base-accessors
+base-components
 yandasoft


### PR DESCRIPTION
I've added some changes to the base-components repo - that I think mirror your cmake improvements - but the build is not working. The tests cannot find the include files in askap-askap. So not sure whether this is ready to accept. 

the base-components branch is cmake-improvements